### PR TITLE
RTK query를 사용해 API 요청 기능 구현

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 declare module '*.svg' {
   const url: string;
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;

--- a/src/redux/api/normalizers.ts
+++ b/src/redux/api/normalizers.ts
@@ -1,0 +1,187 @@
+import { FolderInfo, ImageInfo, PostCommentInfo, PostInfo, SuggestInfo, TagInfo, UserInfo } from '../storeTypes';
+import { Folder, Image, Post, PostComment, Suggest, Tag, User } from './types/fetchData';
+
+export function imageDataNormalizer(image: Image): ImageInfo;
+export function imageDataNormalizer(image: Image[]): ImageInfo[];
+export function imageDataNormalizer(image: Image | Image[]): ImageInfo | ImageInfo[] {
+  if (!Array.isArray(image)) {
+    return {
+      id: image.id,
+      description: image.description,
+      type: image.type,
+      hasSound: image.has_sound,
+      imageWidth: image.width,
+      imageHeight: image.height,
+      bandWidth: image.bandwidth,
+    } as ImageInfo;
+  } else {
+    const images = image;
+    return images.map(image => ({
+      id: image.id,
+      description: image.description,
+      type: image.type,
+      hasSound: image.has_sound,
+      imageWidth: image.width,
+      imageHeight: image.height,
+      bandWidth: image.bandwidth,
+    })) as ImageInfo[];
+  }
+}
+
+export function tagDataNormalizer(tag: Tag): TagInfo;
+export function tagDataNormalizer(tag: Tag[]): TagInfo[];
+export function tagDataNormalizer(tag: Tag | Tag[]): TagInfo | TagInfo[] {
+  if (!Array.isArray(tag)) {
+    return {
+      name: tag.name,
+      postCount: tag.total_items,
+      backgroundImageId: tag.background_hash,
+      description: tag.description,
+    };
+  } else {
+    const tags = tag;
+    return tags.map(tag => ({
+      name: tag.name,
+      postCount: tag.total_items,
+      backgroundImageId: tag.background_hash,
+      description: tag.description,
+    }));
+  }
+}
+
+export function postDataNormalizer(tag: Post): PostInfo;
+export function postDataNormalizer(tag: Post[]): PostInfo[];
+export function postDataNormalizer(post: Post[] | Post): PostInfo | PostInfo[] {
+  if (!Array.isArray(post)) {
+    return {
+      id: post.id,
+      title: post.title,
+      dateTime: post.datetime,
+      thumbnailImageId: post.cover,
+      thumbnailWidth: post.cover_width,
+      thumbnailHeight: post.cover_height,
+      accountName: post.account_url,
+      accountId: post.account_id,
+      views: post.views,
+      upCount: post.ups,
+      downCount: post.downs,
+      points: post.points,
+      commentCount: post.comment_count,
+      favoriteCount: post.favorite_count,
+      images: imageDataNormalizer(post.images) as ImageInfo[],
+      tags: tagDataNormalizer(post.tags) as TagInfo[],
+    };
+  } else {
+    const posts = post;
+    return posts
+      .map(post => {
+        if (!post.images) {
+          return null;
+        }
+        return {
+          id: post.id,
+          title: post.title,
+          dateTime: post.datetime,
+          thumbnailImageId: post.cover,
+          thumbnailWidth: post.cover_width,
+          thumbnailHeight: post.cover_height,
+          accountName: post.account_url,
+          accountId: post.account_id,
+          views: post.views,
+          upCount: post.ups,
+          downCount: post.downs,
+          points: post.points,
+          commentCount: post.comment_count,
+          favoriteCount: post.favorite_count,
+          images: imageDataNormalizer(post.images) as ImageInfo[],
+          tags: tagDataNormalizer(post.tags) as TagInfo[],
+        };
+      })
+      .filter(Boolean);
+  }
+}
+
+export function suggestDataNormalizer(suggest: Suggest): SuggestInfo {
+  return {
+    users: suggest.users.map(user => ({
+      name: user.url,
+      avatarUrl: user.avatar,
+    })),
+    tags: suggest.tags.map(tag => ({
+      name: tag.name,
+      backgroundImageId: tag.background_hash,
+    })),
+    posts: suggest.posts.map(post => ({
+      id: post.hash,
+      title: post.title,
+    })),
+  };
+}
+
+export function userDataNormalizer(user: User): UserInfo;
+export function userDataNormalizer(user: User[]): UserInfo[];
+export function userDataNormalizer(user: User | User[]): UserInfo | UserInfo[] {
+  if (!Array.isArray(user)) {
+    return {
+      id: user.id.toString(),
+      name: user.url,
+      bio: user.bio,
+      avatarUrl: user.avatar,
+      coverUrl: user.cover,
+      createdDate: user.created,
+      notoriety: user.reputation_name,
+      points: user.reputation,
+    };
+  } else {
+    const users = user;
+    return users.map(user => ({
+      id: user.id.toString(),
+      name: user.url,
+      bio: user.bio,
+      avatarUrl: user.avatar,
+      coverUrl: user.cover,
+      createdDate: user.created,
+      notoriety: user.reputation_name,
+      points: user.reputation,
+    }));
+  }
+}
+export function commentNormalizer(comment: PostComment): PostCommentInfo;
+export function commentNormalizer(comment: PostComment[]): PostCommentInfo[];
+export function commentNormalizer(comment: PostComment | PostComment[]): PostCommentInfo | PostCommentInfo[] {
+  if (!Array.isArray(comment)) {
+    return {
+      author: comment.author,
+      comment: comment.comment,
+      dateTime: comment.datetime,
+      downCount: comment.downs,
+      upCount: comment.ups,
+      id: comment.id.toString(),
+      parentCommentId: comment.parent_id.toString(),
+      postId: comment.image_id,
+      thumbnailImageId: comment.album_cover,
+      childrenComments: comment.children ? commentNormalizer(comment.children) : null,
+    };
+  } else {
+    const comments = comment;
+    return comments.map(comment => ({
+      author: comment.author,
+      comment: comment.comment,
+      dateTime: comment.datetime,
+      downCount: comment.downs,
+      upCount: comment.ups,
+      id: comment.id.toString(),
+      parentCommentId: comment.parent_id.toString(),
+      postId: comment.image_id,
+      thumbnailImageId: comment.album_cover,
+      childrenComments: comment.children ? commentNormalizer(comment.children) : null,
+    }));
+  }
+}
+
+export function folderNormalizer(folders: Folder[]): FolderInfo[] {
+  return folders.map(folder => ({
+    id: folder.id,
+    name: folder.name,
+  }));
+}

--- a/src/redux/api/types/fetchData.ts
+++ b/src/redux/api/types/fetchData.ts
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface Suggest {
+  users: User[];
+  tags: Tag[];
+  posts: { type: 'post'; hash: string; title: string }[];
+}
+
+interface Hashtag {
+  indices: number[];
+  tag: string;
+}
+
+interface DescriptionAnnotations {
+  hashtag: Hashtag[];
+}
+
+export interface Tag {
+  name: string;
+  display_name: string;
+  followers: number;
+  total_items: number;
+  following: boolean;
+  is_whitelisted: boolean;
+  background_hash: string;
+  thumbnail_hash?: any;
+  accent: string;
+  background_is_animated: boolean;
+  thumbnail_is_animated: boolean;
+  is_promoted: boolean;
+  description: string;
+  logo_hash?: any;
+  logo_destination_url?: any;
+  description_annotations: DescriptionAnnotations;
+}
+
+export interface Image {
+  id: string;
+  title?: any;
+  description: string;
+  datetime: number;
+  type: 'image/jpeg' | 'video/mp4';
+  animated: boolean;
+  width: number;
+  height: number;
+  size: number;
+  views: number;
+  bandwidth: any;
+  vote?: any;
+  favorite: boolean;
+  nsfw?: any;
+  section?: any;
+  account_url?: any;
+  account_id?: any;
+  is_ad: boolean;
+  in_most_viral: boolean;
+  has_sound: boolean;
+  tags: any[];
+  ad_type: number;
+  ad_url: string;
+  edited: string;
+  in_gallery: boolean;
+  link: string;
+  comment_count?: any;
+  favorite_count?: any;
+  ups?: any;
+  downs?: any;
+  points?: any;
+  score?: any;
+  mp4_size?: number;
+  mp4: string;
+  gifv: string;
+  hls: string;
+  processing: Processing;
+  looping?: boolean;
+}
+
+interface AdConfig {
+  safeFlags: string[];
+  highRiskFlags: any[];
+  unsafeFlags: string[];
+  wallUnsafeFlags: any[];
+  showsAds: boolean;
+}
+
+interface Processing {
+  status: string;
+}
+
+export interface Post {
+  id: string;
+  title: string;
+  description: string;
+  datetime: number;
+  cover: string;
+  cover_width: number;
+  cover_height: number;
+  account_url: string;
+  account_id: number;
+  privacy: string;
+  layout: string;
+  views: number;
+  link: string;
+  ups: number;
+  downs: number;
+  points: number;
+  score: number;
+  is_album: boolean;
+  vote?: any;
+  favorite: boolean;
+  nsfw: boolean;
+  section: string;
+  comment_count: number;
+  favorite_count: number;
+  topic?: any;
+  topic_id?: number;
+  images_count: number;
+  in_gallery: boolean;
+  is_ad: boolean;
+  tags: Tag[];
+  ad_type: number;
+  ad_url: string;
+  in_most_viral: boolean;
+  include_album_ads: boolean;
+  images: Image[];
+  ad_config?: AdConfig;
+  processing: Processing;
+}
+
+// Users
+
+interface UserFollow {
+  status: boolean;
+}
+
+export interface User {
+  id: number;
+  url: string;
+  bio?: string | null;
+  avatar: string;
+  avatar_name: string;
+  cover: string;
+  cover_name: string;
+  reputation: number;
+  reputation_name: string;
+  created: number;
+  pro_expiration: boolean;
+  user_follow: UserFollow;
+}
+
+// Comments
+
+export interface PostComment {
+  id: number;
+  image_id: string;
+  comment: string;
+  author: string;
+  author_id: number;
+  on_album: boolean;
+  album_cover: string;
+  ups: number;
+  downs: number;
+  points: number;
+  datetime: number;
+  parent_id: number;
+  deleted: boolean;
+  vote?: any;
+  platform: string;
+  has_admin_badge: boolean;
+  children?: PostComment[];
+}
+
+// Fav Folder
+
+export interface Folder {
+  id: string;
+  account_id: string;
+  name: string;
+  link: string;
+  created_at: string;
+  updated_at: string;
+  account_url: string;
+  cover_hash: null;
+  cover_width: null;
+  cover_height: null;
+  is_private: boolean;
+}

--- a/src/redux/api/types/queries.ts
+++ b/src/redux/api/types/queries.ts
@@ -1,0 +1,37 @@
+export interface GalleryQuery {
+  section?: 'hot' | 'top' | 'user';
+  sort?: 'viral' | 'top' | 'time' | 'rising';
+  window?: 'day' | 'week' | 'month' | 'year' | 'all';
+  page?: number;
+  showViral?: boolean;
+  showMature?: boolean;
+  albumPreviews?: boolean;
+}
+export interface GallerySearchQuery {
+  sort?: 'viral' | 'top' | 'time';
+  window?: 'day' | 'week' | 'month' | 'year' | 'all';
+  page?: number;
+  keyword: string;
+}
+export interface SuggestQuery {
+  keyword: string;
+}
+export interface PostCommentQuery {
+  postId: string;
+  sort?: 'best' | 'top' | 'new';
+}
+export interface AccountCommentQuery {
+  username: string;
+  sort?: 'best' | 'worst' | 'oldest' | 'newest';
+  page?: number;
+}
+export interface AccountPostQuery {
+  username: string;
+  page?: number;
+}
+export interface accountFavoriteFolderQuery {
+  username: string;
+  folderId: string;
+  page?: number;
+  sort?: 'oldest' | 'newest';
+}

--- a/src/redux/api/v3.ts
+++ b/src/redux/api/v3.ts
@@ -118,4 +118,6 @@ export const {
   useAccountFoldersQuery,
   useAccountPostsQuery,
   useAccountQuery,
+  useSuggestQuery,
+  usePostCommentsQuery,
 } = imgurV3Api;

--- a/src/redux/api/v3.ts
+++ b/src/redux/api/v3.ts
@@ -1,0 +1,121 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { FolderInfo, PostCommentInfo, PostInfo, SuggestInfo, UserInfo } from '../storeTypes';
+import {
+  commentNormalizer,
+  folderNormalizer,
+  postDataNormalizer,
+  suggestDataNormalizer,
+  userDataNormalizer,
+} from './normalizers';
+import { Folder, Post, PostComment, Suggest, User } from './types/fetchData';
+import {
+  AccountCommentQuery,
+  accountFavoriteFolderQuery,
+  AccountPostQuery,
+  GalleryQuery,
+  GallerySearchQuery,
+  PostCommentQuery,
+} from './types/queries';
+
+export const imgurV3Api = createApi({
+  reducerPath: 'imgurApi3',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'https://api.imgur.com/3/',
+    prepareHeaders: headers => {
+      headers.set('Authorization', `Client-ID ${process.env.CLIENT_ID}`);
+      return headers;
+    },
+  }),
+  endpoints: builder => ({
+    gallery: builder.query<PostInfo[], GalleryQuery>({
+      query: ({
+        albumPreviews = true,
+        showMature = false,
+        page = 1,
+        section = 'hot',
+        showViral = true,
+        sort = 'rising',
+        window = 'all',
+      }) =>
+        `gallery/${section}/${sort}/${window}/${page}?showViral=${showViral}&mature=${showMature}&album_previews=${albumPreviews}`,
+      transformResponse: (res: { data: Post[] }) => {
+        const { data } = res;
+        return postDataNormalizer(data);
+      },
+    }),
+    search: builder.query<PostInfo[], GallerySearchQuery>({
+      query: ({ sort = 'time', window = 'all', page = 1, keyword }) =>
+        `gallery/search/${sort}/${window}/${page}?q=${keyword}`,
+      transformResponse: (res: { data: Post[] }) => {
+        const { data } = res;
+        return postDataNormalizer(data);
+      },
+    }),
+    suggest: builder.query<SuggestInfo, string>({
+      query: keyword => `suggest?inflate=users,tags&q=${keyword}&types=users,tags,posts`,
+      transformResponse: (res: { data: Suggest }) => {
+        const { data } = res;
+        return suggestDataNormalizer(data);
+      },
+    }),
+    account: builder.query<UserInfo, string>({
+      query: username => `account/${username}`,
+      transformResponse: (res: { data: User }) => {
+        const { data } = res;
+        return userDataNormalizer(data);
+      },
+    }),
+    accountComments: builder.query<PostCommentInfo[], AccountCommentQuery>({
+      query: ({ page = 0, sort = 'newest', username }) => `account/${username}/comments/${sort}/${page}`,
+      transformResponse: (res: { data: PostComment[] }) => {
+        const { data } = res;
+        return commentNormalizer(data);
+      },
+    }),
+    accountPosts: builder.query<PostInfo[], AccountPostQuery>({
+      query: ({ username, page = 0 }) => `account/${username}/submissions/${page}`,
+      transformResponse: (res: { data: Post[] }) => {
+        const { data } = res;
+        return postDataNormalizer(data);
+      },
+    }),
+    accountFolders: builder.query<FolderInfo[], string>({
+      query: username => `account/${username}/folders?order=asc&per_page=150&sort=name`,
+      transformResponse: (res: { data: Folder[] }) => {
+        const { data } = res;
+        return folderNormalizer(data);
+      },
+    }),
+    accountFolderPosts: builder.query<PostInfo[], accountFavoriteFolderQuery>({
+      query: ({ username, folderId, sort = 'newest', page = 0 }) => {
+        if (folderId) {
+          return `account/${username}/folders/${folderId}/favorites?page=${page}&sort=${sort}`;
+        } else {
+          return `account/${username}/gallery_favorites/${page}/${sort}`;
+        }
+      },
+      transformResponse: (res: { data: Post[] }) => {
+        const { data } = res;
+        return postDataNormalizer(data);
+      },
+    }),
+
+    postComments: builder.query<PostCommentInfo[], PostCommentQuery>({
+      query: ({ postId, sort = 'best' }) => `gallery/${postId}/comments/${sort}`,
+      transformResponse: (res: { data: PostComment[] }) => {
+        const { data } = res;
+        return commentNormalizer(data);
+      },
+    }),
+  }),
+});
+
+export const {
+  useGalleryQuery,
+  useSearchQuery,
+  useAccountCommentsQuery,
+  useAccountFolderPostsQuery,
+  useAccountFoldersQuery,
+  useAccountPostsQuery,
+  useAccountQuery,
+} = imgurV3Api;

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,14 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { useDispatch, useStore } from 'react-redux';
+import { imgurV3Api } from './api/v3';
 import displayReducer from './slices/displayReducer';
 import listInfoReducer from './slices/listInfoReducer';
-import { DisplayInfo, ListInfo } from './storeTypes';
 
-export const store = configureStore<{ listInfo: ListInfo; display: DisplayInfo }>({
-  reducer: { listInfo: listInfoReducer, display: displayReducer },
+export const store = configureStore({
+  reducer: { listInfo: listInfoReducer, display: displayReducer, [imgurV3Api.reducerPath]: imgurV3Api.reducer },
   devTools: {
     trace: true,
   },
+  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(imgurV3Api.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/redux/storeTypes.ts
+++ b/src/redux/storeTypes.ts
@@ -25,7 +25,7 @@ export interface PostInfo {
 
 export interface TagInfo {
   name: string;
-  postCount: number;
+  postCount: number /* total_items */;
   backgroundImageId: string /* background_hash */;
   description: string;
 }
@@ -44,4 +44,39 @@ export interface DisplayInfo {
   innerWidth: number;
   innerHeight: number;
   scrollOffset: number;
+}
+
+export interface SuggestInfo {
+  users: Pick<UserInfo, 'name' | 'avatarUrl'>[];
+  tags: Pick<TagInfo, 'name' | 'backgroundImageId'>[];
+  posts: Pick<PostInfo, 'id' | 'title'>[];
+}
+
+export interface UserInfo {
+  id: string;
+  name: string /* url */;
+  bio: string | null;
+  avatarUrl: string;
+  coverUrl: string;
+  points: number /* reputation */;
+  notoriety: string /* reputation_name */;
+  createdDate: number /* created */;
+}
+
+export interface PostCommentInfo {
+  id: string;
+  postId: string;
+  thumbnailImageId: string;
+  comment: string;
+  author: string;
+  upCount: number;
+  downCount: number;
+  parentCommentId: string;
+  dateTime: number;
+  childrenComments?: PostCommentInfo[];
+}
+
+export interface FolderInfo {
+  id: string;
+  name: string;
 }


### PR DESCRIPTION
### RTK query를 사용해 아래의 쿼리요청을 보낼 수 있음
- useGalleryQuery : 메인의 포스트 리스트
- useSearchQuery : 검색 포스트 리스트
- useSuggestQuery : 자동완성
- useAccountCommentsQuery : 사용자가 쓴 댓글
- useAccountFolderPostsQuery : 사용자의 Fav폴더안의 포스트들
- useAccountFoldersQuery : 사용자의 Fav폴더 목록
- useAccountPostsQuery : 사용자가 올린 포스트
- useAccountQuery : 사용자 정보
- usePostCommentsQuery : 포스트 내부에 있는 댓글