### PR TITLE
fix: module 순서 변경

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,5 @@
-export { default as Avatar } from './Avatar/Avatar';
 export { default as Button } from './Button/Button';
+export { default as Avatar } from './Avatar/Avatar';
 export { default as Image } from './Image/Image';
 export { default as PostHeader } from './PostHeader/PostHeader';
 export * from './Image/Image.type';


### PR DESCRIPTION
컴포넌트 import후 호출시 TypeError: Can not read Properties of undefined라는 오류 메세지가 출력되며, Module.Button 과 Module.Avatar에 문제가 있는 듯한 문구가 출력됨

모듈 순서를 변경하여 문제 해결