### PR TITLE
오류 수정

### DIFF
--- a/src/components/MainContainer/MainContainer.styled.tsx
+++ b/src/components/MainContainer/MainContainer.styled.tsx
@@ -15,8 +15,6 @@ export const ContainerWrapper = styled.div<ContainerWrapperProps>`
 
 export const HeaderCover = styled.header<HeaderCoverProps>`
   width: 100%;
-  min-width: ${pxToRem(450)};
-  max-width: ${pxToRem(1264)};
   height: auto;
   display: flex;
   flex-direction: column;
@@ -41,7 +39,6 @@ export const HeaderCover = styled.header<HeaderCoverProps>`
   `
       : ''}
   transition: box-shadow 0.3s;
-  ${({ containerWidth }) => `padding: 0 calc((100% - ${pxToRem(containerWidth)}) / 2)`};
   padding-top: ${({ headerHeight }) => pxToRem(headerHeight)};
 `;
 

--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -1,3 +1,4 @@
+import { pxToRem } from '@/util/styleUtils';
 import React, { createContext, ReactElement, useLayoutEffect, useRef, useState } from 'react';
 import BasicHeader from './BasicHeader/BasicHeader';
 import {
@@ -114,7 +115,14 @@ export default function MainContainer({
           hasShadow={showCustomHeader}
           containerWidth={containerWidth}
         >
-          {headerCover ?? <div style={{ height: BASIC_HEADER_HEIGHT }} />}
+          <div
+            css={`
+              width: ${pxToRem(containerWidth)};
+              min-width: ${pxToRem(450)};
+            `}
+          >
+            {headerCover ?? <div style={{ height: BASIC_HEADER_HEIGHT }} />}
+          </div>
         </HeaderCover>
         <MainSection ref={mainSectionRef} coverHeight={coverHeight} containerWidth={containerWidth}>
           {children}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,10 +1,9 @@
-import MainContainer from '@/components/MainContainer/MainContainer';
-import React, { ReactElement } from 'react';
 import { Loading, MasonryGallery, MasonryGalleryHeader } from '@/components/index';
+import MainContainer from '@/components/MainContainer/MainContainer';
 import { useTypedSelector } from '@/redux';
-import { masonryGalleryWidthSelector } from '@/redux/slices/displayReducer';
 import { useGalleryQuery } from '@/redux/api';
-import { MASONRY_GALLERY_HEADER_MIN_WIDTH__PX } from '@/components/MasonryGalleryHeader/MasonryGalleryHeader';
+import { masonryGalleryWidthSelector } from '@/redux/slices/displayReducer';
+import React, { ReactElement } from 'react';
 
 export default function Home(): ReactElement {
   // API 호출


### PR DESCRIPTION
headerCover의 width를 직접 조작하니 배경이 짤리는 문제가 발생

전부터 cover의 사이즈를 결정하기 위해 복잡하게 padding을 계산하는 등 비용이 크게 들었음.
결국 div를 두겹으로 감싸서 headerCover의 사이즈를 조정